### PR TITLE
Update macros

### DIFF
--- a/Klipper/Voron_2.4_250/client_macros.cfg
+++ b/Klipper/Voron_2.4_250/client_macros.cfg
@@ -7,7 +7,7 @@
 # [include client_macros.cfg]
 
 [gcode_macro CANCEL_PRINT]
-rename_existing: BASE_CANCEL_PRINT
+rename_existing: KLIPPER_CANCEL_PRINT
 gcode:
   G92 E0                         ; zero the extruder
   G1 E-25 F3600                  ; retract filament for seepage
@@ -16,16 +16,15 @@ gcode:
   G91                            ; relative positioning
   G1 Z1.00 F2400                 ; raise Z
   G90                            ; absolute positioning  
-  G0  X245 Y245 F3600            ; park nozzle at rear right ## Should move this to purge bucket location
+  Purge_Bucket_Park 
   CLEAR_PAUSE
   SDCARD_RESET_FILE
-  BASE_CANCEL_PRINT
+  KLIPPER_CANCEL_PRINT
 
 [gcode_macro PAUSE]
 ## I dont use this ever right now. Refine when I want to use pauses.
-rename_existing: BASE_PAUSE
-# change this if you need more or less extrusion
-variable_extrude: 1.0
+rename_existing: KLIPPER_PAUSE
+variable_extrude: 1.0            ; change this if you need more or less extrusion
 gcode:
   ##### read E from pause macro #####
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
@@ -43,16 +42,16 @@ gcode:
   {% endif %}
   ##### end of definitions #####
   SAVE_GCODE_STATE NAME=PAUSE_state
-  BASE_PAUSE
+  KLIPPER_PAUSE
   G91
-  G1 E-{E} F2100
+  G1 E-{E} F2100                 ; retract
   G1 Z{z_safe} F900
   G90
   G1 X{x_park} Y{y_park} F6000
 
 [gcode_macro RESUME]
 ## I dont use this ever right now. Refine when I want to use pauses.
-rename_existing: BASE_RESUME
+rename_existing: KLIPPER_RESUME
 gcode:
   ##### read E from pause macro #####
   {% set E = printer["gcode_macro PAUSE"].extrude|float %}
@@ -60,7 +59,7 @@ gcode:
   G91
   G1 E{E} F2100
   RESTORE_GCODE_STATE NAME=PAUSE_state
-  BASE_RESUME
+  KLIPPER_RESUME
 
 # Virtual SD Card
 [virtual_sdcard]

--- a/Klipper/Voron_2.4_250/macros.cfg
+++ b/Klipper/Voron_2.4_250/macros.cfg
@@ -13,7 +13,7 @@ gcode:
     {% endif %}
     QUAD_GANTRY_LEVEL
     G28 Z
-    G0 Y125 Z7 F3600
+    G0 Y200 Z7 F3600
 
 ;[gcode_macro G29]
 ;gcode:
@@ -37,8 +37,8 @@ gcode:
     {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(160)|float %}   ; Take EXTRUDER_TEMP from slicer params and set to var EXTRUDER_TEMP 
     
     ;Preheat bed
-    M190 S{BED_TEMP} ; Set bed temp and wait                            ; Tell the Bed to heat up to the target temp set by slicer with a wait
-    
+    M190 S{BED_TEMP} ; Set bed temp and wait                            ; Tell the Bed to heat up to the target temp set by slicer with a wait    
+
     ;HEAT_SOAK
     {% set target  = params.BED_TEMP|int %}                             ; Use the previously defined target bed temp from slicer and set it to var `target`
 	{% set current = printer.heater_bed.temperature %}                  ; Jinja2 expressions are evaluated at start of a macro. var `current` is set equal to actual bed temp at time of PRINT_START
@@ -60,51 +60,29 @@ gcode:
     ; Setup
     M220 S100                                                           ; Reset Feedrate
     M221 S100                                                           ; Reset Flowrate
+    G92 E0                                                              ; Reset Extruder
 
     ; Home and raise nozzle
     G32                                                                 ; home all axes
-    G92 E0                                                              ; Reset Extruder
     G1 Z7.0 F3000                                                       ; Move Z Axis up
 
     ; Purge Bucket Move before heat
-    G1 X10 Y250                                                         ; Left side of purge bucket - ! Create purge bucket park macro
-    G1 Z5                                                               ; Move Z down after reaching location
+    Purge_Bucket_Park
 
     ; Prepare Extruder
     M104 S{EXTRUDER_TEMP}                                               ; Set final nozzle temp  - ! Why did I put this here if I have M109 right after....
     M109 S{EXTRUDER_TEMP}                                               ; Wait for final nozzle temp
     
-    ; Nozzle Brush Wipe
-    G1 Y250 Z3
-    G1 X70                                                              ; Scrub Right
-    G1 X35                                                              ; Scrub Left
-    G1 X70                                                              ; Scrub Right
-    G1 X35                                                              ; Scrub Left
-    G1 X70                                                              ; Scrub Right
-    G1 Z7
-
-    ; Rehome Z
-    G28 Z                                                               ; Home Z only after nozzle scrub
-    G1 Z7                                                               ; Raise Z before travel
-
-    ; primeline
-    G1 X1 Y1 F5000.0                                                    ; Move to X/Y start position
-    G1 E25 F3600                                                        ; Unretract from Print End or Cancel. - !! This sucks if you forget to retract after a filament change
-    G92 E0                                                              ; Reset Extruder
-    G1 Z0.20 F5000.0                                                    ; Move to Z start position
-    G1 X200 Y1.0 Z0.20 F1500.0 E15                                      ; Draw the first line
-    G1 X200 Y1.4 Z0.20 F1500.0                                          ; Move to side a little
-    G1 X1 Y1.4 Z0.20 F1500.0 E30                                        ; Draw the second line
-    G92 E0                                                              ; Reset Extruder
-    G1 Z2.0 F3000                                                       ; Move Z Axis up
+    Purge_Bucket_Scrub                                                  ; Nozzle Brush Wipe
+    Prime_Line                                                          ; Run Primeline
    
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
-   M400                                                                 ; wait for buffer to clear
+    M400                                                                ; wait for buffer to clear
     G92 E0                                                              ; zero the extruder
     G1 E-25.0 F3600                                                     ; retract filament #default was -2, adding more to prevent dingleberries ###############
-    G92 E0                                                              ;Reset Extruder
+    G92 E0                                                              ; Reset Extruder
     G91                                                                 ; relative positioning
     G1 Z1.00 F2400                                                      ; raise Z ########## removed -2 retract due to above line.
     G0 Z1.00 X5.0 Y5.0 F20000                                           ; move nozzle to remove stringing
@@ -112,7 +90,7 @@ gcode:
     M107                                                                ; turn off fan
     G1 Z2 F3000                                                         ; move nozzle up 2mm
     G90                                                                 ; absolute positioning
-    G0  X10 Y245 F3600                                                   ; park nozzle at rear
+    Purge_Bucket_Park                                                   ; park nozzle at rear
     BED_MESH_CLEAR
 
 #####################################################################
@@ -130,24 +108,44 @@ gcode:
     PID_CALIBRATE HEATER=heater_bed TARGET=60
     SAVE_CONFIG  
 
+
 #####################################################################
 # General
+#####################################################################
+
+[gcode_macro Purge_Bucket_Park]
+gcode:
+    G1 X10 Y250                                                         ; Left side of purge bucket - ! Create purge bucket park macro
+    G1 Z7                                                               ; Move Z down after reaching location
+
+[gcode_macro Purge_Bucket_Scrub]
+gcode:
+    G1 Y250 Z3
+    G1 X70                                                              ; Scrub Right
+    G1 X35                                                              ; Scrub Left
+    G1 X70                                                              ; Scrub Right
+    G1 X35                                                              ; Scrub Left
+    G1 X70                                                              ; Scrub Right
+    G1 Z7                                                               ; Raise Z before travel
+    G28 Z                                                               ; Home Z only after nozzle scrub
+    G1 Z7                                                               ; Raise Z before travel
+
+[gcode_macro Prime_Line]
+gcode:
+    G1 X1 Y1 F5000.0                                                    ; Move to X/Y start position
+    G1 E25 F3600                                                        ; Unretract from Print End or Cancel. - !! This sucks if you forget to retract after a filament change
+    G92 E0                                                              ; Reset Extruder
+    G1 Z0.20 F5000.0                                                    ; Move to Z start position
+    G1 X200 Y1.0 Z0.20 F1500.0 E15                                      ; Draw the first line
+    G1 X200 Y1.4 Z0.20 F1500.0                                          ; Move to side a little
+    G1 X1 Y1.4 Z0.20 F1500.0 E30                                        ; Draw the second line
+    G92 E0                                                              ; Reset Extruder
+    G1 Z2.0 F3000                                                       ; Move Z Axis up    
+
+#####################################################################
+# Custom
 #####################################################################
 
 [gcode_macro Move_Front_Center]
 gcode:
     G0 X125 Y0 Z150
-
-[gcode_macro Filament_Unload_ABS]
-gcode:
-    M109 S240
-    G1 E-100 F3600
-    G92 E0                                                               ;Reset Extruder
-
-[gcode_macro Filament_Reload_ABS]
-gcode:
-    M109 S240
-    G1 E100 F3600
-    G92 E0                                                               ;Reset Extruder
-    G4 P{ 0.25 * 60 * 1000 }
-    G1 E-25.0 F3600                                                      ; retract filament #default was -2, adding more to prevent dingleberries ###############


### PR DESCRIPTION
Issue: #6 

- Breakout purge bucket functions to separate macros
-  Call those macros where the code was originally
  - e.g. purge bucket initial travel location can now be called as command so that Cancel and Print End have consistent park locations
 
